### PR TITLE
Remove inexistent target exported library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS
   LIBRARIES
-    ${PROJECT_NAME}
   CATKIN_DEPENDS
     rospy
     std_msgs


### PR DESCRIPTION
This caused issues in building libraries, that depend on vojext_uc1_punching_machine_driver